### PR TITLE
GDPR compliance

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -187,7 +187,7 @@ class helper_plugin_semantic extends DokuWiki_Plugin {
         '@context' => 'http://schema.org',
         '@type'    => 'Person',
         'name'     => $author,
-        'email'    => $user_data['mail']
+        #'email'    => $user_data['mail']
       );
 
       if (isset($this->meta['contributor'])) {
@@ -197,7 +197,7 @@ class helper_plugin_semantic extends DokuWiki_Plugin {
             '@context' => 'http://schema.org',
             '@type'    => 'Person',
             'name'     => $fullname,
-            'email'    => $contributor_data['mail']
+            #'email'    => $contributor_data['mail']
           );
         }
       }


### PR DESCRIPTION
Even if the email is hidden at all other places this plugin can give out the email by default without user consent. We can add option in admin to take consent. email is not mandatory in this structure. https://search.google.com/structured-data/testing-tool also doesn't flag a missing email as either warning or error.

I tested this and several other changes at wiki.ekvastra.in