### PR TITLE
It is allowed to make no selection for license in the configuration. In such case we get error logs

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -205,7 +205,7 @@ class helper_plugin_semantic extends DokuWiki_Plugin
         $license        = $this->getLicense();
         $type           = $this->getSchemaOrgType();
         $user_data      = ($this->getConf('hideMail') ? array('mail' => null) : $auth->getUserData($this->getAuthorID()));
-        $license_url    = $license['url'];
+        $license_url    = (isset($license['url']) ? $license['url'] : null);
         $page_url       = wl($this->page, '', true);
         $description    = str_replace("\n", ' ', $this->getDescription());
         $created        = date(DATE_W3C, $this->getCreatedDate());


### PR DESCRIPTION
If the user continues with no license then the error_log is flooded with the following kind of error logs: [01-Mar-2023 14:55:22 Asia/Kolkata] PHP Warning:  Trying to access array offset on value of type null in /home/ekvastra/wiki.ekvastra.in/lib/plugins/semantic/helper.php on line 208