### PR TITLE
Fallback from page's first image to wiki logo

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -105,16 +105,6 @@ class helper_plugin_semantic extends DokuWiki_Plugin
     }
 
     /**
-     * Get the URL of the first image in page
-     *
-     * @return string
-     */
-    public function getFirstImageURL()
-    {
-        return ($this->getFirstImage() ? ml($this->getFirstImage(), '', true, '&amp;', true) : null);
-    }
-
-    /**
      * Get page description
      *
      * @return string
@@ -392,7 +382,7 @@ class helper_plugin_semantic extends DokuWiki_Plugin
             $locale .= '_' . strtoupper($locale);
         }
 
-        $images = this->getImageData();
+        $images = $this->getImageData();
 
         $open_graph = array(
 


### PR DESCRIPTION
Currently the `og:image` tag will be empty if the page has no images on it.

A slightly better outcome would be setting it to the wiki logo image if there is no image on the page, which is what this PR does.

Thanks for the useful plugin!